### PR TITLE
dbtable naming in 000_migrations changed from lowercase to uppercase

### DIFF
--- a/resources/migrations/000_migrations.yaml
+++ b/resources/migrations/000_migrations.yaml
@@ -5250,7 +5250,7 @@ databaseChangeLog:
         - onFail: MARK_RAN
         - onUpdateSQL: RUN
         - tableExists:
-            tableName: databasechangelog
+            tableName: DATABASECHANGELOG
       changes:
         - sql:
             sql: >-
@@ -5258,7 +5258,7 @@ databaseChangeLog:
               SET archived = NOT archived
               WHERE EXISTS (
                 SELECT *
-                FROM databasechangelog dbcl
+                FROM DATABASECHANGELOG dbcl
                 WHERE dbcl.id = '84'
                   AND metric.updated_at < dbcl.dateexecuted
               )


### PR DESCRIPTION
This is a hotfix targeting new metabase users, which want to run the run the db schema changes manually.

The posted migrations will not execute correctly, due to a typo, which results in following sql error:
ERROR 1146 (42S02) at line 1137: Table 'databasechangelog' doesn't exist

The correct table name is DATABASECHANGELOG, which is also correctly referenced in resources/migrations/000_migrations.yaml more than once. But one time there is a query with databasechangelog on line 5253 and 5361, which breaks the migrations.


###### Before submitting the PR, please make sure you do the following
- [ ] If you're attempting to fix a translation issue, please submit your changes to our [POEditor project](https://poeditor.com/join/project/ynjQmwSsGh) instead of opening a PR.
### Tests
-  [ ] Run the frontend and integration tests with  `yarn lint && yarn flow && yarn test`)
-  [ ] If there are changes to the backend codebase, run the backend tests with `lein test && lein lint && ./bin/reflection-linter`

-  [x] Sign the [Contributor License Agreement](https://docs.google.com/a/metabase.com/forms/d/1oV38o7b9ONFSwuzwmERRMi9SYrhYeOrkbmNaq9pOJ_E/viewform)
(unless it's a tiny documentation change).
